### PR TITLE
Update sync.yml

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Daily Sync Fork
 
 on:
   schedule:
-    - cron: '08 17 * * *'  # Every day at 1:00 AM UTC
+    - cron: '25 17 * * *'  # Every day at 1:00 AM UTC
   workflow_dispatch:      # Allows you to run it manually too
 
 jobs:


### PR DESCRIPTION
### Change Daily Sync Fork GitHub workflow execution time from 17:08 UTC to 17:25 UTC in sync.yml
The cron schedule in [.github/workflows/sync.yml](https://github.com/DojoPrasso/libxmtp/pull/2/files#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7) is modified from `'08 17 * * *'` to `'25 17 * * *'`, shifting the daily execution time by 17 minutes. The workflow comment remains unchanged and shows an inconsistency with the actual scheduled time.

#### 📍Where to Start
Start with the cron schedule configuration in [.github/workflows/sync.yml](https://github.com/DojoPrasso/libxmtp/pull/2/files#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7).

----

_[Macroscope](https://primary.lb.app.staging.web.nonprod.prasso.ai) summarized a94ec65._