### PR TITLE
docs: add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@
   </p>
 </p>
 
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Development](#development)
+- [Tips & Tricks](#tips--tricks)
+  - [Log Output Flags for Tests](#log-output-flags-for-tests)
+- [Quick Start (Dev Containers)](#quick-start-dev-containers)
+- [Quick Start (nix)](#quick-start-nix)
+- [Structure](#structure)
+  - [Run the benchmarks](#run-the-benchmarks)
+- [Code Coverage](#code-coverage)
+- [Contributing](#contributing)
+
 ## Requirements
 
 - [Rustup](https://rustup.rs/)


### PR DESCRIPTION
## Summary
- Add a Table of Contents near the top of `README.md` linking to the main sections (Requirements, Development, Tips & Tricks, Quick Start, Structure, Code Coverage, Contributing).
- Pure docs change — no code touched.

## Test plan
- [x] Render `README.md` on GitHub and confirm all anchor links jump to the correct headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)